### PR TITLE
Change purple status line to scheme color when no folder selected

### DIFF
--- a/themes/base16-ocean.dark.json
+++ b/themes/base16-ocean.dark.json
@@ -374,6 +374,7 @@
         "tab.inactiveBackground": "#1c1f26",
         "statusBar.background": "#1c1f26",
         "statusBar.foreground": "#eff1f5",
+        "statusBar.noFolderBackground": "#1c1f26",
         "statusBar.debuggingBackground": "#230000",
         "titleBar.inactiveBackground": "#1c1f26",
         "titleBar.activeBackground": "#1c1f26",


### PR DESCRIPTION
When VSCode opens w/o opened folder, status line renders incorrectly.
See related issue: https://github.com/ionutvmi/spacegray-vscode/issues/8

This PR fixes this situation, and switch color to background color of scheme.

How to test:
1. Open this file locally
> ~/.vscode/extensions/ionutvmi.spacegray-vscode-1.2.3/themes/base16-ocean.dark.json
2. Under `colors` section add next line
> 377: "statusBar.noFolderBackground": "#1c1f26"
3. Save this file and open VSCode to see related changes

Alternative solution is to add these lines to your settings.json:
```
"workbench.colorCustomizations": {
  "statusBar.noFolderBackground" : "#1c1f26"
}
```