### PR TITLE
Update base16-eighties.dark.json

### DIFF
--- a/themes/base16-eighties.dark.json
+++ b/themes/base16-eighties.dark.json
@@ -357,7 +357,10 @@
         "editor.foreground": "#d3d0c8",
         "editorWhitespace.foreground": "#747369",
         "editor.lineHighlightBackground": "#74736930",
-        "editor.selectionBackground": "#515151"
+        "editor.selectionBackground": "#515151",
+        "statusBar.background": "#3b3b3b",
+        "statusBarItem.remoteBackground" : "#3b3b3b",
+        "statusBarItem.remoteForeground" : "#ffffff"
     },
     "colorSpaceName": "sRGB", 
     "author": "Mihai Ionut Vilcu (http://github.com/ionutvmi)", 


### PR DESCRIPTION
Added status bar colors for eighties.dark

![eighties dark](https://user-images.githubusercontent.com/12409127/69904282-c7dcea00-13df-11ea-948f-8263029d5443.png)
